### PR TITLE
Updated boostrap.js to 1.1.rev16

### DIFF
--- a/toolbarbutton.css
+++ b/toolbarbutton.css
@@ -24,7 +24,7 @@
   	/*start - support for classic theme restorer addon*/
 	toolbar[id="ctr_addon-bar"] > #navigator-throbber,
 	toolbar[id="ctraddon_addon-bar"] > #navigator-throbber {
-		margin: 1px 3px 0px 3px !important;
+		margin: 0px 3px 0px 3px !important;
 	}
 	/*end - support for classic theme restorer addon*/
 	


### PR DESCRIPTION
One of the last couple CTR updates adjusted the way "toolbar items" were placed, and as such the margin here needed to be tweaked.
